### PR TITLE
Add link to admin notices post

### DIFF
--- a/description.txt
+++ b/description.txt
@@ -51,4 +51,6 @@ https://github.com/phpearth/help
 https://php.earth/contributors
 
 🤝 ADMINS:
-https://php.earth/team
+- https://php.earth/team
+- Have questions or experiencing issues? Ask admins here:
+fb.com/groups/2204685680/permalink/10156916600625681


### PR DESCRIPTION
This patch adds a link to post intended for communication between admins and group members.